### PR TITLE
initial v10 compatibility

### DIFF
--- a/legActions.js
+++ b/legActions.js
@@ -42,12 +42,7 @@ export class LegActions extends FormApplication {
     // find the attack being used, by name
     let attack = legToken.actor.items.getName(elem.attr("id"));
 
-    // Thanks D&D5e System!
-    if ( attack.data.type === "spell" ) {
-      legToken.useSpell(attack);
-    } else {
-      attack.roll();
-    }
+    attack.use();
 
     elem.parent().parent().find("button").prop("disabled",true);
 

--- a/module.json
+++ b/module.json
@@ -1,19 +1,33 @@
 {
-    "name": "legendary-training-wheels",
+    "id": "legendary-training-wheels",
     "title": "Legendary Training Wheels",
     "description": "This module provides reminders for lair actions, legendary actions, & resistances.",
     "version": "Replaced in releases",
-    "minimumCoreVersion": "9",
-    "compatibleCoreVersion": "9",
-    "author": "Ethck",
-    "system": [
-        "dnd5e"
+    "authors": [
+        {
+            "name": "Ethck"
+        }
     ],
+    "compatibility": {
+        "minimum": "10",
+        "verified": "10.291"
+    },
+    "relationships": {
+        "systems": [{
+            "id": "dnd5e",
+            "type": "system",
+            "manifest": "https://raw.githubusercontent.com/foundryvtt/dnd5e/master/system.json",
+            "compatibility": {
+              "verified": "2.0.3"
+            }
+          }
+        ]
+    },
     "esmodules": [
-        "/wheels.js"
+        "./wheels.js"
     ],
     "styles": [
-        "/css/wheels.css"
+        "./css/wheels.css"
     ],
     "url": "https://github.com/ethck/legendary-training-wheels",
     "manifest": "https://github.com/Ethck/legendary-training-wheels/releases/latest/download/module.json",

--- a/templates/legendary-actions.html
+++ b/templates/legendary-actions.html
@@ -12,7 +12,7 @@
         <li style="display: flex; flex: 0 1 auto;">
         <button type="button" name="{{legend._id}}" id="{{attack.name}}" style="display: flex;">
           <span style="flex: 1;">{{attack.name}}</span>
-          <span style="flex-basis: 100px; margin-left: auto;">{{attack.data.consume.amount}} {{localize "DND5E.Action"}}</span>
+          <span style="flex-basis: 100px; margin-left: auto;">{{attack.consume.amount}} {{localize "DND5E.Action"}}</span>
         </button>
       </li>
       {{/each}}


### PR DESCRIPTION
All these changes make the module work in Vanilla v10. This does break compatibility with v9. This should be fine, since v9 users will not be able to upgrade, but they also shouldn't need more fixes.

The support for `Better Rolls 5e` needs to be removed, as that module isn't available for 5e. And this module should be tested with `Ready Set Roll for 5E` but these can/will come in separate pull request.